### PR TITLE
Make service optional to support Docker

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 #   Specifies the user to run Atlantis under.
 #
 # @param group
+#   Specifies the state of the Atlantis service. Defaults to 'running'.
+#
+# @param service_ensure
 #   Specifies the group to run Atlantis under.
 #
 # @param manage_user
@@ -47,6 +50,7 @@ class atlantis (
   Array $environment = [],
   String $user = 'atlantis',
   String $group = 'atlantis',
+  Optional[Variant[String,Boolean]] $service_ensure = 'running',
   Boolean $manage_user = true,
   Boolean $manage_group = true,
   String $version = 'v0.6.0',
@@ -103,16 +107,20 @@ class atlantis (
   }
   contain atlantis::config
 
-  class { 'atlantis::service':
-    user              => $user,
-    group             => $group,
-    repo_config       => $repo_config,
-    add_net_bind_caps => $_add_net_bind_caps,
+  if $::atlantis::service_ensure {
+    class { 'atlantis::service':
+      user              => $user,
+      group             => $group,
+      repo_config       => $repo_config,
+      service_ensure    => $service_ensure,
+      add_net_bind_caps => $_add_net_bind_caps,
+    }
+    contain atlantis::service
+
+    Class['atlantis::config'] ~> Class['atlantis::service']
   }
-  contain atlantis::service
 
   Class['atlantis::install']
   -> Class['atlantis::config']
-  ~> Class['atlantis::service']
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,6 +2,7 @@
 class atlantis::service (
   $user,
   $group,
+  Optional[Variant[String,Boolean]] $service_ensure = 'running',
   $repo_config,
   $add_net_bind_caps,
 ){
@@ -37,7 +38,7 @@ class atlantis::service (
   }
 
   service { 'atlantis':
-    ensure    => running,
+    ensure    => $service_ensure,
     enable    => true,
     subscribe => Exec['atlantis_systemd_daemon-reload'],
   }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Hello,

When systemctl is not present (such as in Docker), the build will fail. I have made the service resource type dependent on a `service_ensure` flag to support this scenario.